### PR TITLE
Use syntax to bind existential type in GADT

### DIFF
--- a/lib/typename.ml
+++ b/lib/typename.ml
@@ -189,12 +189,9 @@ struct
     in
     match data with
     | None -> None
-    | Some (Data (name', data)) ->
-      (fun (type b) (name' : b typename) (data : b X.t) ->
-        let Type_equal.T = (same_witness_exn name' name : (b, a) Type_equal.t) in
-        Some (data : a X.t))
-        name'
-        data
+    | Some (Data (type b) ((name', data) : b typename * b X.t)) ->
+      let Type_equal.T = (same_witness_exn name' name : (b, a) Type_equal.t) in
+      Some (data : a X.t)
   ;;
 end
 


### PR DESCRIPTION
This feature wasn't available back then, now we can make use of it:

    https://ocaml.org/manual/5.2/gadts-tutorial.html#s:explicit-existential-name

(very minor, feel free to ignore I just noticed this randomly while looking into the build for 5.3).